### PR TITLE
Added an exception that is thrown when configuration is invalid

### DIFF
--- a/force-app/main/default/classes/Einstein_ConfigurationException.cls
+++ b/force-app/main/default/classes/Einstein_ConfigurationException.cls
@@ -1,0 +1,2 @@
+public class Einstein_ConfigurationException extends Exception {
+}

--- a/force-app/main/default/classes/Einstein_ConfigurationException.cls-meta.xml
+++ b/force-app/main/default/classes/Einstein_ConfigurationException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="Einstein_ConfigurationException">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/Einstein_PredictionService.cls
+++ b/force-app/main/default/classes/Einstein_PredictionService.cls
@@ -837,8 +837,9 @@ public class Einstein_PredictionService {
     public static String getAccessToken() {
         // Try to retrieve email setting
         Einstein_Settings__c settings = Einstein_Settings__c.getOrgDefaults();
-        if (settings.Einstein_EMail__c == null)
+        if (settings.Einstein_EMail__c == null) {
             throw new Einstein_ConfigurationException('Missing Einstein email setting. Check your Custom Settings.');
+        }
         ContentVersion base64Content;
         // Try to retrieve certificate
         try {

--- a/force-app/main/default/classes/Einstein_PredictionService.cls
+++ b/force-app/main/default/classes/Einstein_PredictionService.cls
@@ -835,8 +835,18 @@ public class Einstein_PredictionService {
     }
     
     public static String getAccessToken() {
+        // Try to retrieve email setting
         Einstein_Settings__c settings = Einstein_Settings__c.getOrgDefaults();
-        ContentVersion base64Content = [SELECT Title, VersionData FROM ContentVersion where Title='einstein_platform' LIMIT 1];
+        if (settings.Einstein_EMail__c == null)
+            throw new Einstein_ConfigurationException('Missing Einstein email setting. Check your Custom Settings.');
+        ContentVersion base64Content;
+        // Try to retrieve certificate
+        try {
+            base64Content = [SELECT Title, VersionData FROM ContentVersion where Title='einstein_platform' LIMIT 1];
+        }
+        catch (QueryException e) {
+            throw new Einstein_ConfigurationException('Could not retrieve the Einstein Platform certificate file: einstein_platform', e);
+        }
         String keyContents = base64Content.VersionData.tostring();
         keyContents = keyContents.replace('-----BEGIN RSA PRIVATE KEY-----', '');
         keyContents = keyContents.replace('-----END RSA PRIVATE KEY-----', '');

--- a/force-app/main/default/classes/Test_Einstein.cls
+++ b/force-app/main/default/classes/Test_Einstein.cls
@@ -7,7 +7,8 @@ public with sharing class Test_Einstein {
             Einstein_PredictionService.getAccessToken();
             System.assert(false, 'Expected Einstein_ConfigurationException');
         }
-        catch (Einstein_ConfigurationException e) {
+        catch (Exception e) {
+            System.assert(e instanceof Einstein_ConfigurationException);
             System.AssertEquals(e.getMessage().contains('email setting'), true);
         }
         Test.stopTest();
@@ -23,7 +24,8 @@ public with sharing class Test_Einstein {
             Einstein_PredictionService.getAccessToken();
             System.assert(false, 'Expected Einstein_ConfigurationException');
         }
-        catch (Einstein_ConfigurationException e) {
+        catch (Exception e) {
+            System.assert(e instanceof Einstein_ConfigurationException);
             System.AssertEquals(e.getMessage().contains('certificate file'), true);
         }
         Test.stopTest();

--- a/force-app/main/default/classes/Test_Einstein.cls
+++ b/force-app/main/default/classes/Test_Einstein.cls
@@ -1,7 +1,48 @@
 @isTest
 public with sharing class Test_Einstein {
 
-    
+    static testMethod void getAccessToken_failsWithoutEmailSetting() {
+        Test.startTest();
+        try {
+            Einstein_PredictionService.getAccessToken();
+            System.assert(false, 'Expected Einstein_ConfigurationException');
+        }
+        catch (Einstein_ConfigurationException e) {
+            System.AssertEquals(e.getMessage().contains('email setting'), true);
+        }
+        Test.stopTest();
+    }
+
+    static testMethod void getAccessToken_failsWithoutCertificate() {
+        Einstein_Settings__c settings = Einstein_Settings__c.getOrgDefaults();
+        settings.Einstein_EMail__c = 'test@mail.com';
+        upsert settings;
+
+        Test.startTest();
+        try {
+            Einstein_PredictionService.getAccessToken();
+            System.assert(false, 'Expected Einstein_ConfigurationException');
+        }
+        catch (Einstein_ConfigurationException e) {
+            System.AssertEquals(e.getMessage().contains('certificate file'), true);
+        }
+        Test.stopTest();
+    }
+
+    static testMethod void getAccessToken_works() {
+        Einstein_Settings__c settings = Einstein_Settings__c.getOrgDefaults();
+        settings.Einstein_EMail__c = 'test@mail.com';
+        upsert settings;
+
+        ContentVersion certificate = new ContentVersion(Title = 'einstein_platform', PathOnClient='.', VersionData=Blob.valueOf('someData'));
+        insert certificate;
+
+        Test.startTest();
+        String token = Einstein_PredictionService.getAccessToken();
+        System.assertEquals(token, '');
+        Test.stopTest();
+    }
+
     static testMethod void createDataset() {
 
         Einstein_PredictionService service = new Einstein_PredictionService('123', Einstein_PredictionService.Types.IMAGE);


### PR DESCRIPTION
Added an `Einstein_ConfigurationException` that is thrown when configuration is invalid:
- missing email setting
- missing certificate file