### PR TITLE
Update sourceApiVersion to Winter'17

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "40.0"
+    "sourceApiVersion": "41.0"
   }


### PR DESCRIPTION
As per the Salesforce DX Sucess group (https://success.salesforce.com/0D53A00003FLMiE), the sourceApiVersion needs to match the highest value used by any of the metadata components.